### PR TITLE
Add sample PBS submission script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ which is available for Mac and Windows.
 To download this example,
 you can use Git:
 
-    git clone https://github.com/mdpiper/simple-dakota-example
+    git clone https://github.com/gregtucker/simple-dakota-example
 
 Or you can download a
-[zip file](https://github.com/mdpiper/simple-dakota-example/archive/master.zip)
+[zip file](https://github.com/gregtucker/simple-dakota-example/archive/master.zip)
 and unpack it.
 
 Change into the **simple-dakota-example** directory
@@ -64,7 +64,7 @@ Dakota, Python, and Git are already installed on ***beach***.
 
 Download this example with:
 
-    git clone https://github.com/mdpiper/simple-dakota-example
+    git clone https://github.com/gregtucker/simple-dakota-example
 
 Change into the **simple-dakota-example** directory
 and submit the run to the job scheduler with:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
-# simple-dakota-example
-Simple example of using Dakota for a parameter study
+# Simple Dakota Example
+
+A simple example of using [Dakota](https://dakota.sandia.gov/)
+iterative systems analysis toolkit
+to perform a parameter study.
+
+## Running this example on your computer
+
+To run this example,
+you'll need
+
+1. Dakota,
+1. Python, and, optionally,
+1. Git
+
+installed on on your computer.
+
+Follow the instructions on the Dakota website
+for [downloading](https://dakota.sandia.gov/download.html) and
+[installing](https://dakota.sandia.gov/content/install-linux-macosx)
+a precompiled Dakota binary for your system.
+
+Macs and Linux distributions come with a Python distribution;
+however, we recommend using the
+[Anaconda](https://www.continuum.io/downloads)
+Python distribution
+because it's easy to install on Mac, Linux, and Windows,
+and it doesn't interefere with any other Python distributions.
+If you don't want to use it, you can delete it without harm.
+
+Likewise, Macs and Linux distributions come with
+[Git](https://git-scm.com/).
+If you're not comfortable using Git,
+try the [GitHub Desktop](https://desktop.github.com/) application,
+which is available for Mac and Windows.
+
+To download this example,
+you can use Git:
+
+    git clone https://github.com/mdpiper/simple-dakota-example
+
+Or you can download a
+[zip file](https://github.com/mdpiper/simple-dakota-example/archive/master.zip)
+and unpack it.
+
+Change into the **simple-dakota-example** directory
+and run the example with:
+
+	cd simple-dakota-example
+	dakota -i dakota_analysis.in -o dakota_run.out &> run.log
+
+When the example completes,
+view the output in **run.log**.
+
+
+## Running this example on beach
+
+[CSDMS](https://csdms.colorado.edu)
+manages an experimental high-performance computing cluster (HPCC),
+***beach***.
+Using an HPCC is different than using a personal computer
+in that work must be submitted through a job scheduler.
+Dakota, Python, and Git are already installed on ***beach***.
+
+Download this example with:
+
+    git clone https://github.com/mdpiper/simple-dakota-example
+
+Change into the **simple-dakota-example** directory
+and submit the run to the job scheduler with:
+
+	cd simple-dakota-example
+	qsub call_dakota.pbs.in
+
+When the example completes,
+view the output in the scheduler output file,
+which will have a name like
+**call_dakota.pbs.sh.o[run_id]**,
+where `[run_id]` is the identifier for a run;
+e.g., **call_dakota.pbs.sh.o226983**.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Change into the **simple-dakota-example** directory
 and submit the run to the job scheduler with:
 
 	cd simple-dakota-example
-	qsub call_dakota.pbs.in
+	qsub call_dakota.pbs.sh
 
 When the example completes,
 view the output in the scheduler output file,

--- a/call_dakota.pbs.sh
+++ b/call_dakota.pbs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# This PBS submission script runs Dakota on the CSDMS HPCC, beach.
+# Call this script with:
+#
+#  $ qsub call_dakota.pbs.sh
+
+# Add Dakota to PATH and LD_LIBRARY_PATH.
+export DAKOTA_DIR=/usr/local/dakota
+PATH=$DAKOTA_DIR/bin:$DAKOTA_DIR/test:$PATH
+if [ $LD_LIBRARY_PATH ]; then
+    LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DAKOTA_DIR/bin:$DAKOTA_DIR/lib
+else
+    export LD_LIBRARY_PATH=$DAKOTA_DIR/bin:$DAKOTA_DIR/lib
+fi
+
+# Push beach's Anaconda Python distribution to the front of PATH.
+PATH=/usr/local/anaconda/bin:$PATH
+
+# Switch to the current working directory and call Dakota.
+cd $PBS_O_WORKDIR
+dakota -i dakota_analysis.in -o dakota_analysis.out


### PR DESCRIPTION
I've included a sample PBS submission script that allows this Dakota example to be run on the CSDMS HPCC, `beach`. This may be handy because it shows that much of the user's environment on the head node of `beach` isn't transferred to the compute nodes, so we have to explicitly set up paths to Dakota and to the Python distribution we wish to use. (I didn't realize this at first!) The drawback of this example is that it includes information particular to `beach` (like the path to Dakota) which may not transfer directly to another HPCC.
